### PR TITLE
add iter8 files

### DIFF
--- a/iter8/basic-deployment/experiment.yaml
+++ b/iter8/basic-deployment/experiment.yaml
@@ -1,0 +1,55 @@
+---
+# Source: deploy/charts/deploy/templates/experiment.yaml
+apiVersion: iter8.tools/v2alpha2
+kind: Experiment
+metadata:
+  # the sha256sum suffix based on candidate is useful; it ensures that 
+  # a new experiment is generated whenever the candidate version is updated 
+  # (for example, by CD pipeline)
+  name: hello-experiment
+spec:
+  # target should uniquely identify the application under experimentation
+  target: hello
+  strategy:
+    # this is an SLO validation experiment
+    testingPattern: Conformance
+    actions:
+      start:
+      # ensure candidate service and deployment of the application are available
+      - task: common/readiness 
+        with:
+          objRefs:
+          - kind: Service
+            name: hello-candidate
+            namespace: NAMESPACE
+          - kind: Deployment
+            name: hello-candidate
+            namespace: NAMESPACE
+            waitFor: condition=available
+      # collect Iter8's built-in metrics
+      - task: metrics/collect
+        with:
+          time: "20s"
+          versions:
+          - name: new-version # this name must match the name of a version in versionInfo
+            url: "http://hello-candidate.NAMESPACE:8080"
+            qps: 8
+  criteria:
+    requestCount: iter8-system/request-count
+    indicators:
+    - iter8-system/error-count
+    # service-level objectives (SLOs) that need to be satisfied by the new version
+    # in order for it to be considered a winner
+    objectives:
+    - metric: iter8-system/mean-latency
+      upperLimit: "500"
+    - metric: iter8-system/error-rate
+      upperLimit: "0.01"
+    - metric: iter8-system/latency-95th-percentile
+      upperLimit: "1000"
+  duration:
+    intervalSeconds: 1
+    iterationsPerLoop: 1
+  versionInfo:
+    baseline:
+      name: new-version

--- a/iter8/basic-deployment/hello-candidate.yaml
+++ b/iter8/basic-deployment/hello-candidate.yaml
@@ -1,0 +1,44 @@
+---
+# Source: deploy/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-candidate
+  labels:
+    app.kubernetes.io/managed-by: Iter8
+    app.kubernetes.io/name: hello
+    app.kubernetes.io/track: candidate
+spec:
+  type: ClusterIP
+  ports:
+  -
+    port: 8080
+  selector:
+    app.kubernetes.io/name: hello
+    app.kubernetes.io/track: candidate
+---
+# Source: deploy/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-candidate
+  labels:
+    app.kubernetes.io/managed-by: Iter8
+    app.kubernetes.io/name: hello
+    app.kubernetes.io/track: candidate
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hello
+      app.kubernetes.io/track: candidate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hello
+        app.kubernetes.io/track: candidate
+    spec:
+      containers:
+      - name: hello
+        image: 'gcr.io/google-samples/hello-app:2.0'
+        ports:
+        - containerPort: 8080

--- a/iter8/progressive-deployment/experiment.yaml
+++ b/iter8/progressive-deployment/experiment.yaml
@@ -1,0 +1,61 @@
+apiVersion: iter8.tools/v2alpha2
+kind: Experiment
+metadata:
+  name: hello-rollout-istio
+spec:
+  # target identifies the service under experimentation using its fully qualified name
+  target: hello
+  strategy:
+    # this experiment will perform an A/B test
+    testingPattern: Canary
+    # this experiment will progressively shift traffic to the winning version
+    deploymentPattern: Progressive
+    actions:
+      loop:
+      # on each loop, send test traffic to all versions (for 10s)
+      - task: metrics/collect
+        with:
+          time: 6s
+          versions:
+          - name: hello
+            url: http://hello.NAMESPACE:8080
+          - name: hello-candidate
+            url: http://hello-candidate.NAMESPACE:8080
+      # when the experiment completes, promote the winning version using kubectl apply
+      finish:
+      - if: CandidateWon()
+        run: kubectl -n @<.Namespace>@ apply -f https://raw.githubusercontent.com/kalantar/iter8/cil-2/samples/cil/second/hello-candidate.yaml
+      - if: not CandidateWon()
+        run: kubectl -n @<.Namespace>@ apply -f https://raw.githubusercontent.com/kalantar/iter8/cil-2/samples/cil/second/hello.yaml
+  criteria:
+    objectives: # used for validating versions
+    - metric: iter8-system/mean-latency
+      upperLimit: 5
+    - metric: iter8-system/error-rate
+      upperLimit: "0.01"
+    - metric: iter8-system/latency-95th-percentile
+      upperLimit: 10
+    requestCount: iter8-system/request-count
+  duration: # product of fields determines length of the experiment
+    intervalSeconds: 1
+    iterationsPerLoop: 1
+    maxLoops: 5
+  versionInfo:
+    # information about the app versions used in this experiment
+    baseline:
+      name: hello
+      weightObjRef:
+        apiVersion: networking.istio.io/v1beta1
+        kind: VirtualService
+        namespace: NAMESPACE
+        name: hello
+        fieldPath: .spec.http[1].route[0].weight
+    candidates:
+    - name: hello-candidate
+      weightObjRef:
+        apiVersion: networking.istio.io/v1beta1
+        kind: VirtualService
+        namespace: NAMESPACE
+        name: hello
+        fieldPath: .spec.http[1].route[1].weight
+

--- a/iter8/progressive-deployment/hello-setup.yaml
+++ b/iter8/progressive-deployment/hello-setup.yaml
@@ -1,0 +1,132 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello
+  labels:
+    app.kubernetes.io/managed-by: Iter8
+    app.kubernetes.io/name: hello
+    app.kubernetes.io/track: baseline
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+  selector:
+    app.kubernetes.io/name: hello
+    app.kubernetes.io/track: baseline
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello
+  labels:
+    app.kubernetes.io/managed-by: Iter8
+    app.kubernetes.io/name: hello
+    app.kubernetes.io/track: baseline
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hello
+      app.kubernetes.io/track: baseline
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hello
+        app.kubernetes.io/track: baseline
+    spec:
+      containers:
+      - name: hello
+        image: gcr.io/google-samples/hello-app:1.0
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-candidate
+  labels:
+    app.kubernetes.io/managed-by: Iter8
+    app.kubernetes.io/name: hello
+    app.kubernetes.io/track: candidate
+spec:
+  type: ClusterIP
+  ports:
+  - port: 8080
+  selector:
+    app.kubernetes.io/name: hello
+    app.kubernetes.io/track: candidate
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-candidate
+  labels:
+    app.kubernetes.io/managed-by: Iter8
+    app.kubernetes.io/name: hello
+    app.kubernetes.io/track: candidate
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hello
+      app.kubernetes.io/track: candidate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hello
+        app.kubernetes.io/track: candidate
+    spec:
+      containers:
+      - name: hello
+        image: gcr.io/google-samples/hello-app:2.0
+        ports:
+        - containerPort: 8080
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: hello
+spec:
+  selector:
+    istio: ingressgateway # use istio default controller
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "hello.example.com"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: hello
+spec:
+  gateways:
+  # - mesh
+  - hello
+  hosts:
+  - hello
+  - "hello.example.com"
+  http:
+  - match:
+    # routing for test traffic targetting the candidate version
+    # assumes has header X-Iter8: candidate
+    - headers:
+        x-iter8:
+          exact: candidate
+    route:
+    - destination:
+        host: hello-candidate.NAMESPACE.svc.cluster.local
+        port:
+          number: 8080
+  # default route -- use distribution
+  - route:
+    - destination:
+        host: hello.NAMESPACE.svc.cluster.local
+        port:
+          number: 8080
+      weight: 100
+    - destination:
+        host: hello-candidate.NAMESPACE.svc.cluster.local
+        port:
+          number: 8080
+      weight: 0


### PR DESCRIPTION
Add yaml files used by Iter8 notebooks [here](https://github.ibm.com/cloud-innovation-lab/iter8-kui/tree/master/plugins/plugin-client-default/notebooks).
Signed-off-by: Michael Kalantar <kalantar@us.ibm.com>